### PR TITLE
refactor: JwtModule 의존성 구조 변경  global → AuthModule export로 대체

### DIFF
--- a/src/auth/AuthModule.ts
+++ b/src/auth/AuthModule.ts
@@ -2,22 +2,10 @@ import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { JwtStrategy } from './strategies/JwtStrategy';
-import { config } from 'src/shared/config/config';
 
 @Module({
-  imports: [
-    PassportModule,
-    JwtModule.registerAsync({
-      global: true,
-      useFactory: async () => ({
-        secret: config.JWT_ACCESS_SECRET,
-        signOptions: {
-          expiresIn: config.JWT_ACCESS_EXPIRES_IN,
-        },
-      }),
-    }),
-  ],
+  imports: [PassportModule, JwtModule],
   providers: [JwtStrategy],
-  exports: [],
+  exports: [JwtModule],
 })
 export class AuthModule {}

--- a/src/user/UserModule.ts
+++ b/src/user/UserModule.ts
@@ -8,9 +8,10 @@ import { FindUserByIdUseCase } from './application/FindUserByIdUseCase/FindUserB
 import { CreateLoginUseCase } from './application/CreateLoginUseCase/CreateLoginUseCase';
 import { UserController } from './presentation/UserController';
 import { CreateReissuedAccessTokenUseCase } from './application/CreateReissuedAccessTokenUseCase/CreateReissuedAccessTokenUseCase';
+import { AuthModule } from 'src/auth/AuthModule';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UserEntitiy])],
+  imports: [TypeOrmModule.forFeature([UserEntitiy]), AuthModule],
   controllers: [UserController],
   providers: [
     FindUserByUsernameUseCase,


### PR DESCRIPTION
JwtService는 이제 AuthModule을 통해 제공되며, global: true 설정은 사용하지 않음